### PR TITLE
make ingress tls disabled by default

### DIFF
--- a/charts/onechart/templates/ingress.yaml
+++ b/charts/onechart/templates/ingress.yaml
@@ -17,10 +17,12 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if default false .tlsEnabled }}
   tls:
     - hosts:
         - {{ .host | quote }}
       secretName: {{ printf "tls-%s" $.Release.Name }}
+  {{- end }}
   rules:
     - host: {{ .host | quote }}
       http:


### PR DESCRIPTION
This would be the new ux:

## No ingress
```
helm template my-release onechart/onechart
```

## Ingress without tls
```
helm template my-release onechart/onechart --set=ingress.host=nginx.lvh.me 
```

## Ingress with tls
```
helm template my-release onechart/onechart --set=ingress.host=nginx.mydomain.com --set=ingress.tlsEnabled=true
```